### PR TITLE
Expand world generation, camera controls, and NPC interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,12 +6,19 @@
     <style>
         body { margin: 0; overflow: hidden; background-color: #333; color: white; font-family: Arial, sans-serif; }
         canvas { display: block; }
-        #ui-container { position: absolute; top: 10px; left: 10px; padding: 10px; background-color: rgba(0,0,0,0.5); border-radius: 5px; }
+        #ui-container { position: absolute; top: 10px; left: 10px; padding: 12px 14px; background-color: rgba(0,0,0,0.5); border-radius: 6px; backdrop-filter: blur(4px); }
         #ui-container p, #ui-container button, #ui-container select { margin: 5px 0; }
         .eye-patch { position: absolute; top: 0; width: 50%; height: 100%; background-color: rgba(0,0,0,0.85); display: none; pointer-events: none; z-index: 1000; }
         #eye-patch-left { left: 0; }
         #eye-patch-right { right: 0; }
-        #loot-panel { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); background-color: rgba(0,0,0,0.8); color: #fff; padding: 20px; border: 1px solid #555; display: none; z-index: 1001; }
+        #loot-panel, #trade-panel { position: absolute; left: 50%; transform: translateX(-50%); min-width: 260px; max-width: 340px; background-color: rgba(0,0,0,0.82); color: #fff; padding: 18px; border: 1px solid #555; border-radius: 8px; display: none; z-index: 1001; box-shadow: 0 12px 24px rgba(0,0,0,0.45); }
+        #loot-panel { top: 18%; }
+        #trade-panel { top: 26%; }
+        #loot-panel h3, #trade-panel h3 { margin-top: 0; }
+        #interaction-hint { position: absolute; bottom: 26px; left: 50%; transform: translateX(-50%); padding: 8px 14px; border-radius: 20px; background-color: rgba(0,0,0,0.6); font-size: 14px; display: none; z-index: 900; }
+        #loot-items p { margin: 6px 0; }
+        #trade-panel button { display: block; width: 100%; margin: 6px 0; padding: 8px; }
+        #trade-status { min-height: 18px; font-size: 14px; color: #d3e6ff; margin-top: 6px; }
     </style>
 </head>
 <body>
@@ -29,9 +36,10 @@
         <p>Текущая фракция: <span id="player-faction">Не выбрана</span></p>
         <p>Здоровье: <span id="player-health">100</span></p>
         <p>Золото: <span id="player-gold">0</span></p>
+        <p>Скорость: <span id="player-speed">5</span></p>
         <button id="save-game">Сохранить</button>
         <button id="load-game">Загрузить</button>
-        <p>Управление: WASD для движения, пробел для атаки</p>
+        <p>Управление: кликните в игру, чтобы повернуть камеру мышью. WASD для движения, пробел для атаки, E — взаимодействие</p>
     </div>
 
     <div id="eye-patch-left" class="eye-patch"></div>
@@ -41,6 +49,15 @@
         <div id="loot-items"></div>
         <button id="close-loot">Закрыть</button>
     </div>
+    <div id="trade-panel">
+        <h3 id="trade-title">Торговец</h3>
+        <p>Золото можно потратить на услуги союзников.</p>
+        <button id="buy-heal">Купить лечение (30 золота)</button>
+        <button id="buy-speed">Заказать быстрых лошадей (80 золота)</button>
+        <div id="trade-status"></div>
+        <button id="close-trade">Закрыть</button>
+    </div>
+    <div id="interaction-hint"></div>
 
     <script type="importmap">
     {

--- a/js/caravans.js
+++ b/js/caravans.js
@@ -2,11 +2,13 @@ import * as THREE from 'three';
 import { createCaravanTexture } from './textures.js';
 
 export class CaravanManager {
-    constructor(scene) {
+    constructor(scene, world) {
         this.scene = scene;
+        this.world = world;
         this.caravans = [];
         this.spawnTimer = 0;
-        this.moveSpeed = 2.2;
+        this.moveSpeed = 2.4;
+        this.spawnInterval = 10;
         this.textures = {
             merchant: createCaravanTexture('merchant'),
             imperial_supply: createCaravanTexture('imperial_supply')
@@ -15,6 +17,8 @@ export class CaravanManager {
             merchant: new THREE.MeshStandardMaterial({ map: this.textures.merchant, roughness: 0.75, metalness: 0.05 }),
             imperial_supply: new THREE.MeshStandardMaterial({ map: this.textures.imperial_supply, roughness: 0.5, metalness: 0.2 })
         };
+        this.roadHalfLength = world.halfSize - 60;
+        this.roadWidth = 70;
     }
 
     spawnCaravan() {
@@ -23,12 +27,15 @@ export class CaravanManager {
         const mesh = new THREE.Mesh(geometry, this.materials[type]);
         mesh.castShadow = true;
         mesh.receiveShadow = true;
-        const startX = -25 + Math.random() * 50;
-        mesh.position.set(startX, 0.6, -28);
+        const roadZ = (Math.random() * 2 - 1) * (this.roadWidth * 0.5);
+        const startX = -this.roadHalfLength;
+        const startHeight = this.world.getHeightAt(startX, roadZ);
+        mesh.position.set(startX, startHeight + 0.65, roadZ);
         const caravan = {
             mesh,
             type,
-            targetZ: 28,
+            targetX: this.roadHalfLength,
+            roadZ,
             elapsed: 0,
             bobOffset: Math.random() * Math.PI * 2,
             speed: this.moveSpeed * (0.8 + Math.random() * 0.4)
@@ -39,18 +46,20 @@ export class CaravanManager {
 
     update(delta) {
         this.spawnTimer += delta;
-        if (this.spawnTimer > 8) {
+        if (this.spawnTimer > this.spawnInterval) {
             this.spawnCaravan();
             this.spawnTimer = 0;
         }
         this.caravans.forEach(c => {
             c.elapsed += delta;
-            c.mesh.position.z += c.speed * delta;
-            c.mesh.position.y = 0.6 + Math.sin(c.elapsed * 2.5 + c.bobOffset) * 0.05;
-            c.mesh.rotation.y = Math.sin(c.elapsed * 1.2 + c.bobOffset) * 0.1;
+            c.mesh.position.x += c.speed * delta;
+            c.mesh.position.z = c.roadZ + Math.sin(c.elapsed * 0.7 + c.bobOffset) * 1.8;
+            const ground = this.world.getHeightAt(c.mesh.position.x, c.mesh.position.z);
+            c.mesh.position.y = ground + 0.65 + Math.sin(c.elapsed * 2.5 + c.bobOffset) * 0.04;
+            c.mesh.rotation.y = Math.sin(c.elapsed * 1.1 + c.bobOffset) * 0.08;
         });
         this.caravans = this.caravans.filter(c => {
-            if (c.mesh.position.z >= c.targetZ) {
+            if (c.mesh.position.x >= c.targetX) {
                 this.scene.remove(c.mesh);
                 return false;
             }

--- a/js/combat.js
+++ b/js/combat.js
@@ -1,6 +1,9 @@
 export function attackCaravan(player, caravanMgr, caravan) {
     const loot = getCaravanLoot(caravan.type);
     player.gold += loot.gold;
+    if (typeof player.addLoot === 'function') {
+        player.addLoot(loot);
+    }
     caravanMgr.removeCaravan(caravan);
     showLootPanel(loot);
     if (Math.random() < 0.3) {
@@ -15,18 +18,58 @@ export function attackCaravan(player, caravanMgr, caravan) {
 }
 
 function showLootPanel(loot) {
+    if (document.pointerLockElement) {
+        document.exitPointerLock();
+    }
     const panel = document.getElementById('loot-panel');
     const itemsDiv = document.getElementById('loot-items');
-    itemsDiv.innerHTML = `<p>Золото: ${loot.gold}</p>`;
+    let html = `<p><strong>Золото:</strong> ${loot.gold}</p>`;
+    if (loot.items && loot.items.length) {
+        html += `<p><strong>Трофеи:</strong> ${loot.items.join(', ')}</p>`;
+    }
+    if (loot.resources && Object.keys(loot.resources).length > 0) {
+        const resList = Object.entries(loot.resources)
+            .map(([key, value]) => `${key}: ${value}`)
+            .join(', ');
+        html += `<p><strong>Ресурсы:</strong> ${resList}</p>`;
+    }
+    if (loot.story) {
+        html += `<p>${loot.story}</p>`;
+    }
+    html += '<p>Золото можно обменять у караванного торговца (нажмите E рядом с ним).</p>';
+    itemsDiv.innerHTML = html;
     panel.style.display = 'block';
 }
 
 function getCaravanLoot(type) {
-    let loot = { gold: 0 };
+    const loot = {
+        gold: 0,
+        items: [],
+        resources: {},
+        story: ''
+    };
+
     if (type === 'merchant') {
-        loot.gold = Math.floor(Math.random() * 100) + 50;
+        loot.gold = Math.floor(Math.random() * 120) + 70;
+        if (Math.random() < 0.6) loot.items.push('Тюки специй');
+        if (Math.random() < 0.45) loot.items.push('Шелковые ткани');
+        loot.story = 'Торговцы жаловались, что не успели спрятать книги учета.';
     } else if (type === 'imperial_supply') {
-        loot.gold = Math.floor(Math.random() * 50) + 20;
+        loot.gold = Math.floor(Math.random() * 70) + 40;
+        loot.resources['Металл'] = Math.floor(Math.random() * 5) + 3;
+        if (Math.random() < 0.4) {
+            loot.items.push('Имперские пайки');
+        }
+        if (Math.random() < 0.25) {
+            loot.items.push('Карта патрулей');
+            loot.story = 'Найдена карта с пометками маршрутов стражи.';
+        } else {
+            loot.story = 'Повозка скрипела от веса оружия и пайков.';
+        }
+    }
+
+    if (loot.items.length === 0) {
+        loot.items.push('Нечто любопытное');
     }
     return loot;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -5,22 +5,38 @@ import { CaravanManager } from './caravans.js';
 import { attackCaravan } from './combat.js';
 import { saveGame, loadGame } from './save.js';
 import { createSkyTexture } from './textures.js';
+import { NPCManager } from './npc.js';
 
 let scene, camera, renderer;
-let player, world, caravans;
+let player, world, caravans, npcManager;
 let lastTime = 0;
 const keys = {};
-const cameraOffset = new THREE.Vector3(0, 5, 10);
+
+const cameraSpherical = new THREE.Spherical(14, 1.05, Math.PI * 1.05);
+const cameraOffset = new THREE.Vector3();
 const desiredCameraPosition = new THREE.Vector3();
 const cameraLookTarget = new THREE.Vector3();
+const cameraTargetOffset = new THREE.Vector3(0, 1.5, 0);
+const cameraForward = new THREE.Vector3();
+const cameraRight = new THREE.Vector3();
+const worldUp = new THREE.Vector3(0, 1, 0);
+
+let pointerLocked = false;
+let currentInteractable = null;
+
+const lootPanel = document.getElementById('loot-panel');
+const tradePanel = document.getElementById('trade-panel');
+const tradeTitle = document.getElementById('trade-title');
+const tradeStatusLabel = document.getElementById('trade-status');
+const interactionHint = document.getElementById('interaction-hint');
 
 function init() {
     scene = new THREE.Scene();
     scene.background = createSkyTexture();
-    scene.fog = new THREE.Fog(0xaecbff, 40, 180);
+    scene.fog = new THREE.Fog(0xaecbff, 120, 850);
 
-    camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 500);
-    camera.position.set(0, 6, 14);
+    camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 2000);
+    camera.position.set(0, 9, 18);
 
     renderer = new THREE.WebGLRenderer({ antialias: true });
     renderer.setPixelRatio(window.devicePixelRatio);
@@ -31,16 +47,44 @@ function init() {
     renderer.toneMappingExposure = 1.0;
     document.body.appendChild(renderer.domElement);
 
+    world = new GameWorld(scene, camera);
+
     player = new Player();
+    player.mesh.position.set(0, 0, 0);
+    player.setGroundHeightProvider((x, z) => world.getHeightAt(x, z));
+    player.setMovementBounds(world.getMovementBounds());
+    player.snapToGround();
     scene.add(player.mesh);
 
-    world = new GameWorld(scene, camera);
-    caravans = new CaravanManager(scene);
+    caravans = new CaravanManager(scene, world);
+    npcManager = new NPCManager(scene, world);
 
+    setupPointerLock();
     setupUI();
     updateUI();
 
     requestAnimationFrame(animate);
+}
+
+function setupPointerLock() {
+    renderer.domElement.addEventListener('click', () => {
+        if (isAnyPanelOpen()) return;
+        renderer.domElement.requestPointerLock();
+    });
+    document.addEventListener('pointerlockchange', () => {
+        pointerLocked = document.pointerLockElement === renderer.domElement;
+        renderer.domElement.style.cursor = pointerLocked ? 'none' : 'default';
+    });
+    document.addEventListener('mousemove', event => {
+        if (!pointerLocked) return;
+        cameraSpherical.theta -= event.movementX * 0.0022;
+        cameraSpherical.phi -= event.movementY * 0.0016;
+        cameraSpherical.phi = THREE.MathUtils.clamp(cameraSpherical.phi, 0.3, 1.4);
+    });
+    renderer.domElement.addEventListener('wheel', event => {
+        cameraSpherical.radius = THREE.MathUtils.clamp(cameraSpherical.radius + event.deltaY * 0.01, 6, 28);
+        event.preventDefault();
+    }, { passive: false });
 }
 
 function setupUI() {
@@ -55,12 +99,35 @@ function setupUI() {
     });
     document.getElementById('load-game').addEventListener('click', () => {
         if (loadGame(player)) {
+            player.snapToGround();
             updateUI();
             alert('Загружено');
         }
     });
     document.getElementById('close-loot').addEventListener('click', () => {
-        document.getElementById('loot-panel').style.display = 'none';
+        lootPanel.style.display = 'none';
+    });
+    document.getElementById('close-trade').addEventListener('click', () => {
+        tradePanel.style.display = 'none';
+        tradeStatusLabel.textContent = '';
+    });
+    document.getElementById('buy-heal').addEventListener('click', () => {
+        if (player.spendGold(30)) {
+            player.heal(35);
+            tradeStatusLabel.textContent = 'Торговец перевязал ваши раны.';
+            updateUI();
+        } else {
+            tradeStatusLabel.textContent = 'Нужно больше золота.';
+        }
+    });
+    document.getElementById('buy-speed').addEventListener('click', () => {
+        if (player.spendGold(80)) {
+            player.applySpeedUpgrade(1.2);
+            tradeStatusLabel.textContent = 'Лошади готовы. Скорость передвижения выросла!';
+            updateUI();
+        } else {
+            tradeStatusLabel.textContent = 'Соберите ещё монеты.';
+        }
     });
     window.addEventListener('resize', onWindowResize);
     window.addEventListener('keydown', e => {
@@ -68,8 +135,13 @@ function setupUI() {
         if (!keys[key]) {
             keys[key] = true;
             if (key === 'space') {
+                if (!isAnyPanelOpen()) {
+                    e.preventDefault();
+                    attemptAttack();
+                }
+            } else if (key === 'e') {
                 e.preventDefault();
-                attemptAttack();
+                attemptInteraction();
             }
         }
     });
@@ -86,6 +158,7 @@ function onWindowResize() {
 }
 
 function updateUI() {
+    if (!player) return;
     const factionNames = {
         elf: 'Лесные Эльфы',
         guard: 'Охрана Дворца',
@@ -94,21 +167,48 @@ function updateUI() {
     document.getElementById('player-faction').textContent = factionNames[player.faction] || 'Не выбрана';
     document.getElementById('player-health').textContent = Math.round(player.health);
     document.getElementById('player-gold').textContent = player.gold;
+    document.getElementById('player-speed').textContent = player.getMoveSpeed().toFixed(1);
+}
+
+function isPanelVisible(element) {
+    if (!element) return false;
+    return getComputedStyle(element).display !== 'none';
+}
+
+function isAnyPanelOpen() {
+    return isPanelVisible(lootPanel) || isPanelVisible(tradePanel);
 }
 
 function handleInput(delta) {
-    const dir = new THREE.Vector3();
-    if (keys['w'] || keys['arrowup']) dir.z -= 1;
-    if (keys['s'] || keys['arrowdown']) dir.z += 1;
-    if (keys['a'] || keys['arrowleft']) dir.x -= 1;
-    if (keys['d'] || keys['arrowright']) dir.x += 1;
-    if (dir.lengthSq() > 0) {
-        dir.normalize();
-        player.move(dir, delta);
+    if (!player || isAnyPanelOpen()) return;
+    const horizontal = (keys['d'] || keys['arrowright'] ? 1 : 0) - (keys['a'] || keys['arrowleft'] ? 1 : 0);
+    const vertical = (keys['w'] || keys['arrowup'] ? 1 : 0) - (keys['s'] || keys['arrowdown'] ? 1 : 0);
+    if (horizontal === 0 && vertical === 0) return;
+
+    cameraForward.subVectors(player.mesh.position, camera.position);
+    cameraForward.y = 0;
+    if (cameraForward.lengthSq() < 0.0001) {
+        cameraForward.set(0, 0, -1);
+    } else {
+        cameraForward.normalize();
+    }
+    cameraRight.crossVectors(cameraForward, worldUp).normalize();
+
+    const input = new THREE.Vector2(horizontal, vertical);
+    if (input.lengthSq() > 1) {
+        input.normalize();
+    }
+    const moveDir = new THREE.Vector3();
+    moveDir.addScaledVector(cameraForward, input.y);
+    moveDir.addScaledVector(cameraRight, input.x);
+    if (moveDir.lengthSq() > 0) {
+        moveDir.normalize();
+        player.move(moveDir, delta);
     }
 }
 
 function attemptAttack() {
+    if (!caravans) return;
     let target = null;
     caravans.caravans.forEach(c => {
         if (!target && c.mesh.position.distanceTo(player.mesh.position) < 2.2) {
@@ -122,11 +222,64 @@ function attemptAttack() {
     }
 }
 
+function attemptInteraction() {
+    if (!currentInteractable || isAnyPanelOpen()) return;
+    if (currentInteractable.interaction === 'trade') {
+        openTradePanel(currentInteractable);
+    }
+}
+
+function openTradePanel(npc) {
+    if (document.pointerLockElement === renderer.domElement) {
+        document.exitPointerLock();
+    }
+    tradeTitle.textContent = npc.displayName;
+    tradeStatusLabel.textContent = 'Есть товары и слухи из дальних земель.';
+    tradePanel.style.display = 'block';
+}
+
+function updateInteractionTargets() {
+    if (!npcManager || !player) return;
+    if (isAnyPanelOpen()) {
+        hideInteractionHint();
+        npcManager.setHighlightedNPC(null);
+        return;
+    }
+    const interactable = npcManager.getNearestInteractable(player.mesh.position, 4.5);
+    if (interactable) {
+        currentInteractable = interactable.npc;
+        npcManager.setHighlightedNPC(interactable.npc);
+        showInteractionHint(`E — поговорить с ${interactable.npc.displayName}`);
+    } else {
+        currentInteractable = null;
+        npcManager.setHighlightedNPC(null);
+        hideInteractionHint();
+    }
+}
+
+function showInteractionHint(text) {
+    if (!interactionHint) return;
+    if (interactionHint.textContent !== text) {
+        interactionHint.textContent = text;
+    }
+    if (interactionHint.style.display !== 'block') {
+        interactionHint.style.display = 'block';
+    }
+}
+
+function hideInteractionHint() {
+    if (!interactionHint) return;
+    if (interactionHint.style.display !== 'none') {
+        interactionHint.style.display = 'none';
+    }
+}
+
 function updateCamera() {
+    if (!player) return;
+    cameraOffset.setFromSpherical(cameraSpherical);
     desiredCameraPosition.copy(player.mesh.position).add(cameraOffset);
-    camera.position.lerp(desiredCameraPosition, 0.08);
-    cameraLookTarget.copy(player.mesh.position);
-    cameraLookTarget.y += 1.5;
+    camera.position.lerp(desiredCameraPosition, 0.12);
+    cameraLookTarget.copy(player.mesh.position).add(cameraTargetOffset);
     camera.lookAt(cameraLookTarget);
 }
 
@@ -138,9 +291,19 @@ function animate(time) {
     }
     lastTime = time;
     handleInput(delta);
-    player.update(delta);
-    caravans.update(delta);
-    world.update(delta);
+    if (player) {
+        player.update(delta);
+    }
+    if (caravans) {
+        caravans.update(delta);
+    }
+    if (world) {
+        world.update(delta);
+    }
+    if (npcManager) {
+        npcManager.update(delta);
+    }
+    updateInteractionTargets();
     updateCamera();
     renderer.render(scene, camera);
 }

--- a/js/npc.js
+++ b/js/npc.js
@@ -1,0 +1,205 @@
+import * as THREE from 'three';
+import { createPlayerTexture } from './textures.js';
+
+const NPC_BASE_HEIGHT = 1.0;
+
+export class NPCManager {
+    constructor(scene, world) {
+        this.scene = scene;
+        this.world = world;
+        this.npcs = [];
+        this.highlightedNPC = null;
+
+        this.textures = {
+            elf: createPlayerTexture('elf'),
+            guard: createPlayerTexture('guard'),
+            villain: createPlayerTexture('villain'),
+            merchant: createPlayerTexture('neutral')
+        };
+
+        this.baseMaterials = {
+            elf: new THREE.MeshStandardMaterial({ map: this.textures.elf, roughness: 0.6, metalness: 0.1, emissive: new THREE.Color(0x0a160a) }),
+            guard: new THREE.MeshStandardMaterial({ map: this.textures.guard, roughness: 0.55, metalness: 0.18, emissive: new THREE.Color(0x080818) }),
+            villain: new THREE.MeshStandardMaterial({ map: this.textures.villain, roughness: 0.58, metalness: 0.16, emissive: new THREE.Color(0x160812) }),
+            merchant: new THREE.MeshStandardMaterial({ map: this.textures.merchant, roughness: 0.62, metalness: 0.08, emissive: new THREE.Color(0x120805) })
+        };
+
+        this.spawnInitialNPCs();
+    }
+
+    spawnInitialNPCs() {
+        // Neutral merchant near the central road
+        this.spawnNPC({
+            type: 'merchant',
+            name: 'Караванный торговец',
+            position: new THREE.Vector3(28, 0, -24),
+            roamRadius: 18,
+            speed: 1.6,
+            interaction: 'trade'
+        });
+
+        // Elf scouts in the forest
+        this.spawnFactionGroup('elf', new THREE.Vector3(-260, 0, 210), 4, 60, [
+            'Следопыт Тир',
+            'Лучница Элин',
+            'Друид Варен',
+            'Следопыт Лиара'
+        ], { speed: 2.6 });
+
+        // Palace guards on imperial lands
+        this.spawnFactionGroup('guard', new THREE.Vector3(220, 0, 130), 4, 55, [
+            'Сержант Маркус',
+            'Страж Ирия',
+            'Капрал Дариус',
+            'Страж Арман'
+        ], { speed: 2.4 });
+
+        // Villain warband in the mountains
+        this.spawnFactionGroup('villain', new THREE.Vector3(310, 0, -260), 3, 45, [
+            'Колдунья Вера',
+            'Воевода Мор',
+            'Громила Затх'
+        ], { speed: 2.5 });
+    }
+
+    spawnFactionGroup(type, center, count, radius, names = [], options = {}) {
+        for (let i = 0; i < count; i++) {
+            const angle = Math.random() * Math.PI * 2;
+            const distance = Math.random() * radius * 0.6;
+            const position = new THREE.Vector3(
+                center.x + Math.cos(angle) * distance,
+                0,
+                center.z + Math.sin(angle) * distance
+            );
+            this.spawnNPC({
+                type,
+                name: names[i % names.length] || `${type}_npc_${i}`,
+                position,
+                roamRadius: radius,
+                speed: options.speed || 2.2
+            });
+        }
+    }
+
+    spawnNPC({ type, name, position, roamRadius = 30, speed = 2.2, interaction = null }) {
+        const mesh = this.createNPCMesh(type);
+        const ground = this.world.getHeightAt(position.x, position.z);
+        mesh.position.set(position.x, ground + NPC_BASE_HEIGHT, position.z);
+        this.scene.add(mesh);
+
+        const npc = {
+            mesh,
+            type,
+            displayName: name,
+            roamCenter: new THREE.Vector3(position.x, 0, position.z),
+            roamRadius,
+            speed,
+            interaction,
+            target: null,
+            thinkTimer: 0,
+            bobTime: Math.random() * Math.PI * 2,
+            baseEmissive: mesh.material.emissive.clone()
+        };
+
+        this.npcs.push(npc);
+        return npc;
+    }
+
+    createNPCMesh(type) {
+        const geometry = new THREE.CapsuleGeometry(0.45, 0.9, 6, 12);
+        const baseMaterial = this.baseMaterials[type] || this.baseMaterials.merchant;
+        const material = baseMaterial.clone();
+        material.emissiveIntensity = 0.65;
+        const mesh = new THREE.Mesh(geometry, material);
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        mesh.position.y = NPC_BASE_HEIGHT;
+
+        // Simple shoulder pad to differentiate factions visually
+        const shoulderGeometry = new THREE.SphereGeometry(0.25, 12, 12);
+        const shoulderMaterial = new THREE.MeshStandardMaterial({
+            color: type === 'villain' ? 0x5b1e5e : type === 'guard' ? 0x41496a : type === 'elf' ? 0x2f7a42 : 0x8b5524,
+            roughness: 0.5,
+            metalness: 0.3,
+            emissive: new THREE.Color(0x050505)
+        });
+        const shoulders = new THREE.Group();
+        const left = new THREE.Mesh(shoulderGeometry, shoulderMaterial);
+        const right = new THREE.Mesh(shoulderGeometry, shoulderMaterial);
+        left.position.set(-0.5, 1.1, 0);
+        right.position.set(0.5, 1.1, 0);
+        shoulders.add(left);
+        shoulders.add(right);
+        mesh.add(shoulders);
+        return mesh;
+    }
+
+    chooseNewTarget(npc) {
+        const attempts = 6;
+        for (let i = 0; i < attempts; i++) {
+            const angle = Math.random() * Math.PI * 2;
+            const distance = Math.random() * npc.roamRadius;
+            const x = npc.roamCenter.x + Math.cos(angle) * distance;
+            const z = npc.roamCenter.z + Math.sin(angle) * distance;
+            const height = this.world.getHeightAt(x, z);
+
+            const slope = Math.abs(height - this.world.getHeightAt(x + 4, z)) + Math.abs(height - this.world.getHeightAt(x, z + 4));
+            if (slope > 10) continue;
+
+            return new THREE.Vector3(x, height + NPC_BASE_HEIGHT, z);
+        }
+        const centerHeight = this.world.getHeightAt(npc.roamCenter.x, npc.roamCenter.z);
+        return new THREE.Vector3(npc.roamCenter.x, centerHeight + NPC_BASE_HEIGHT, npc.roamCenter.z);
+    }
+
+    update(delta) {
+        const moveDir = new THREE.Vector3();
+        this.npcs.forEach(npc => {
+            npc.thinkTimer -= delta;
+            if (npc.thinkTimer <= 0 || !npc.target) {
+                npc.target = this.chooseNewTarget(npc);
+                npc.thinkTimer = 4 + Math.random() * 6;
+            }
+
+            moveDir.copy(npc.target).sub(npc.mesh.position);
+            const distanceSq = moveDir.x * moveDir.x + moveDir.z * moveDir.z;
+            if (distanceSq > 0.2) {
+                moveDir.y = 0;
+                moveDir.normalize();
+                npc.mesh.position.addScaledVector(moveDir, npc.speed * delta);
+                npc.mesh.rotation.y = Math.atan2(moveDir.x, moveDir.z);
+            }
+
+            npc.bobTime += delta * 2.2;
+            const ground = this.world.getHeightAt(npc.mesh.position.x, npc.mesh.position.z);
+            npc.mesh.position.y = ground + NPC_BASE_HEIGHT + Math.sin(npc.bobTime + npc.displayName.length) * 0.05;
+        });
+    }
+
+    getNearestInteractable(position, maxDistance = 4) {
+        let nearest = null;
+        let minDistSq = maxDistance * maxDistance;
+        for (const npc of this.npcs) {
+            if (!npc.interaction) continue;
+            const distSq = npc.mesh.position.distanceToSquared(position);
+            if (distSq < minDistSq) {
+                nearest = npc;
+                minDistSq = distSq;
+            }
+        }
+        if (!nearest) return null;
+        return { npc: nearest, distance: Math.sqrt(minDistSq) };
+    }
+
+    setHighlightedNPC(npc) {
+        if (this.highlightedNPC === npc) return;
+        if (this.highlightedNPC) {
+            this.highlightedNPC.mesh.material.emissive.copy(this.highlightedNPC.baseEmissive);
+        }
+        this.highlightedNPC = npc || null;
+        if (npc) {
+            npc.mesh.material.emissive.copy(npc.baseEmissive).lerp(new THREE.Color(0xffff99), 0.45);
+        }
+    }
+}
+

--- a/js/save.js
+++ b/js/save.js
@@ -4,7 +4,9 @@ export function saveGame(player) {
         health: player.health,
         gold: player.gold,
         bodyParts: { ...player.bodyParts },
-        position: player.mesh.position.toArray()
+        position: player.mesh.position.toArray(),
+        speedBonus: player.speedBonus || 0,
+        inventory: Array.isArray(player.inventory) ? [...player.inventory] : []
     };
     localStorage.setItem('caravanSagaSave', JSON.stringify(data));
 }
@@ -23,6 +25,15 @@ export function loadGame(player) {
     player.bodyParts = { ...data.bodyParts };
     if (Array.isArray(data.position)) {
         player.mesh.position.fromArray(data.position);
+    }
+    if (typeof data.speedBonus === 'number') {
+        player.speedBonus = data.speedBonus;
+    }
+    if (Array.isArray(data.inventory)) {
+        player.inventory = [...data.inventory];
+    }
+    if (typeof player.snapToGround === 'function') {
+        player.snapToGround();
     }
     if (!player.bodyParts.leftEye) document.getElementById('eye-patch-left').style.display = 'block';
     else document.getElementById('eye-patch-left').style.display = 'none';

--- a/js/world.js
+++ b/js/world.js
@@ -5,12 +5,18 @@ import {
     createLeafTexture,
     createLeafBillboardTexture
 } from './textures.js';
+import { generatePerlinMap } from './noise.js';
 
 export class GameWorld {
     constructor(scene, camera) {
         this.scene = scene;
         this.camera = camera;
         this.trees = [];
+        this.terrainSize = 1600;
+        this.terrainSegments = 256;
+        this.heightScale = 46;
+        this.halfSize = this.terrainSize / 2;
+        this.heightField = new Float32Array((this.terrainSegments + 1) * (this.terrainSegments + 1));
         this.treeTextures = {
             bark: createBarkTexture(),
             leaves: createLeafTexture(),
@@ -29,45 +35,116 @@ export class GameWorld {
     }
 
     setup() {
-        const hemiLight = new THREE.HemisphereLight(0xbfd8ff, 0x3d2a18, 0.6);
+        const hemiLight = new THREE.HemisphereLight(0xbfd8ff, 0x3d2a18, 0.65);
         this.scene.add(hemiLight);
 
-        const dirLight = new THREE.DirectionalLight(0xffffff, 1.0);
-        dirLight.position.set(30, 60, 40);
+        const dirLight = new THREE.DirectionalLight(0xffffff, 1.1);
+        dirLight.position.set(220, 320, 180);
         dirLight.castShadow = true;
         dirLight.shadow.mapSize.set(2048, 2048);
-        dirLight.shadow.camera.left = -120;
-        dirLight.shadow.camera.right = 120;
-        dirLight.shadow.camera.top = 120;
-        dirLight.shadow.camera.bottom = -120;
-        dirLight.shadow.camera.far = 200;
+        dirLight.shadow.camera.left = -400;
+        dirLight.shadow.camera.right = 400;
+        dirLight.shadow.camera.top = 360;
+        dirLight.shadow.camera.bottom = -280;
+        dirLight.shadow.camera.near = 10;
+        dirLight.shadow.camera.far = 1200;
         this.scene.add(dirLight);
 
-        const zones = [
-            { type: 'neutral', x: 0 },
-            { type: 'imperial', x: 50 },
-            { type: 'forest', x: -50 },
-            { type: 'villain', x: 100 }
-        ];
-        zones.forEach(zone => {
-            const texture = createGroundTexture(zone.type);
-            const material = new THREE.MeshStandardMaterial({
-                map: texture,
-                roughness: 0.95,
-                metalness: 0.0
-            });
-            const plane = new THREE.Mesh(new THREE.PlaneGeometry(50, 50), material);
-            plane.rotation.x = -Math.PI / 2;
-            plane.position.x = zone.x;
-            plane.receiveShadow = true;
-            this.scene.add(plane);
+        this.createTerrain();
+        this.populateTrees();
+        this.createLandmarks();
+    }
+
+    createTerrain() {
+        const geometry = new THREE.PlaneGeometry(this.terrainSize, this.terrainSize, this.terrainSegments, this.terrainSegments);
+        const positions = geometry.attributes.position;
+        const vertexCount = positions.count;
+        const sampleSize = this.terrainSegments + 1;
+
+        const noise = generatePerlinMap(sampleSize, sampleSize, {
+            scale: 0.003,
+            octaves: 5,
+            persistence: 0.52,
+            lacunarity: 2.1,
+            seed: 5123
         });
 
-        for (let i = 0; i < 28; i++) {
-            const x = (Math.random() - 0.5) * 140;
-            const z = (Math.random() - 0.5) * 140;
-            this.addTree(new THREE.Vector3(x, 0, z));
+        for (let i = 0; i < vertexCount; i++) {
+            const ix = i % sampleSize;
+            const iz = Math.floor(i / sampleSize);
+            const x = (ix / this.terrainSegments) * this.terrainSize - this.halfSize;
+            const z = (iz / this.terrainSegments) * this.terrainSize - this.halfSize;
+            const distance = Math.sqrt(x * x + z * z);
+            const normalizedDistance = Math.min(1, distance / (this.terrainSize * 0.52));
+            const falloff = Math.pow(Math.max(0, 1 - normalizedDistance), 3.2);
+            const plateau = Math.pow(Math.max(0, 1 - distance / (this.terrainSize * 0.18)), 3.5) * 11;
+            const noiseValue = noise[iz * sampleSize + ix];
+            const shapedNoise = (noiseValue - 0.5) * this.heightScale;
+            const height = THREE.MathUtils.clamp(shapedNoise * (0.35 + falloff * 0.7) + plateau - normalizedDistance * 12, -18, 38);
+
+            positions.setXYZ(i, x, height, z);
+            this.heightField[iz * sampleSize + ix] = height;
         }
+
+        geometry.computeVertexNormals();
+        positions.needsUpdate = true;
+
+        const texture = createGroundTexture('neutral');
+        texture.repeat.set(24, 24);
+        const material = new THREE.MeshStandardMaterial({
+            map: texture,
+            roughness: 0.92,
+            metalness: 0.04
+        });
+
+        this.terrain = new THREE.Mesh(geometry, material);
+        this.terrain.receiveShadow = true;
+        this.scene.add(this.terrain);
+    }
+
+    populateTrees() {
+        const desiredCount = 260;
+        const maxAttempts = desiredCount * 8;
+        let attempts = 0;
+        while (this.trees.length < desiredCount && attempts < maxAttempts) {
+            attempts++;
+            const x = (Math.random() * 2 - 1) * this.halfSize;
+            const z = (Math.random() * 2 - 1) * this.halfSize;
+            if (Math.abs(x) < 60 && Math.abs(z) < 80) continue;
+            const height = this.getHeightAt(x, z);
+            if (height > 28 || height < -8) continue;
+            const slope = Math.abs(height - this.getHeightAt(x + 6, z)) + Math.abs(height - this.getHeightAt(x, z + 6));
+            if (slope > 9) continue;
+
+            const position = new THREE.Vector3(x, height, z);
+            this.addTree(position);
+        }
+    }
+
+    createLandmarks() {
+        const material = new THREE.MeshStandardMaterial({ color: 0x6b4523, roughness: 0.8 });
+        const geometry = new THREE.CylinderGeometry(1.6, 1.6, 4.2, 12);
+        const bannerMaterial = new THREE.MeshStandardMaterial({ color: 0xd6b25e, roughness: 0.5, metalness: 0.2 });
+
+        const campPositions = [
+            { pos: new THREE.Vector3(-240, 0, 200), color: 0x2f7a42 },
+            { pos: new THREE.Vector3(210, 0, 110), color: 0x3c4b8e },
+            { pos: new THREE.Vector3(290, 0, -240), color: 0x5b1e5e }
+        ];
+
+        campPositions.forEach(camp => {
+            const h = this.getHeightAt(camp.pos.x, camp.pos.z);
+            const totem = new THREE.Mesh(geometry, material.clone());
+            totem.position.set(camp.pos.x, h + 2.1, camp.pos.z);
+            totem.castShadow = true;
+            this.scene.add(totem);
+
+            const banner = new THREE.Mesh(new THREE.BoxGeometry(0.2, 3.2, 1.8), bannerMaterial.clone());
+            banner.material.color.setHex(camp.color);
+            banner.position.set(camp.pos.x, h + 3.2, camp.pos.z + 0.9);
+            banner.castShadow = true;
+            this.scene.add(banner);
+        });
     }
 
     addTree(position) {
@@ -75,7 +152,7 @@ export class GameWorld {
         const treeMesh = this.createTreeMesh();
         const sprite = this.createTreeSprite();
         lod.addLevel(treeMesh, 0);
-        lod.addLevel(sprite, 28);
+        lod.addLevel(sprite, 360);
         lod.position.copy(position);
         this.scene.add(lod);
         this.trees.push({
@@ -117,8 +194,8 @@ export class GameWorld {
         const spriteMaterial = this.treeSpriteMaterial.clone();
         spriteMaterial.rotation = (Math.random() - 0.5) * 0.1;
         const sprite = new THREE.Sprite(spriteMaterial);
-        sprite.scale.set(4.5, 6.5, 1);
-        sprite.position.set(0, 3.2, 0);
+        sprite.scale.set(5.5, 7.4, 1);
+        sprite.position.set(0, 3.6, 0);
         return sprite;
     }
 
@@ -133,5 +210,35 @@ export class GameWorld {
                 foliage.position.x = Math.sin(tree.time * 0.8 + tree.swayOffset) * 0.1;
             }
         });
+    }
+
+    getHeightAt(x, z) {
+        const clampedX = THREE.MathUtils.clamp(x, -this.halfSize, this.halfSize);
+        const clampedZ = THREE.MathUtils.clamp(z, -this.halfSize, this.halfSize);
+        const normalizedX = (clampedX + this.halfSize) / this.terrainSize;
+        const normalizedZ = (clampedZ + this.halfSize) / this.terrainSize;
+
+        const gridX = normalizedX * this.terrainSegments;
+        const gridZ = normalizedZ * this.terrainSegments;
+        const x0 = Math.floor(gridX);
+        const z0 = Math.floor(gridZ);
+        const x1 = Math.min(x0 + 1, this.terrainSegments);
+        const z1 = Math.min(z0 + 1, this.terrainSegments);
+        const sx = gridX - x0;
+        const sz = gridZ - z0;
+        const size = this.terrainSegments + 1;
+
+        const h00 = this.heightField[z0 * size + x0];
+        const h10 = this.heightField[z0 * size + x1];
+        const h01 = this.heightField[z1 * size + x0];
+        const h11 = this.heightField[z1 * size + x1];
+
+        const hx0 = THREE.MathUtils.lerp(h00, h10, sx);
+        const hx1 = THREE.MathUtils.lerp(h01, h11, sx);
+        return THREE.MathUtils.lerp(hx0, hx1, sz);
+    }
+
+    getMovementBounds() {
+        return this.halfSize - 24;
     }
 }


### PR DESCRIPTION
## Summary
- add pointer-lock camera controls, trading UI, and interaction hints so gold has uses and panels no longer trap the cursor
- regenerate the map with a large Perlin-noise terrain, distant tree LOD, and faction landmarks instead of four flat tiles
- populate the world with roaming faction NPCs, a caravan merchant, and caravans that follow the reshaped landscape

## Testing
- npm test *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_68c9cfc694b8833094b7aa21a331e7d5